### PR TITLE
Prepare for release v2024.6.4

### DIFF
--- a/docs/CHANGELOG-v2024.6.4.md
+++ b/docs/CHANGELOG-v2024.6.4.md
@@ -1,0 +1,110 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2024.6.4
+    name: Changelog-v2024.6.4
+    parent: welcome
+    weight: 20240604
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.6.4/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.6.4/
+---
+
+# KubeStash v2024.6.4 (2024-06-04)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.9.0](https://github.com/kubestash/apimachinery/releases/tag/v0.9.0)
+
+- [ec8b5051](https://github.com/kubestash/apimachinery/commit/ec8b5051) Remove deprecated markers
+- [126c3590](https://github.com/kubestash/apimachinery/commit/126c3590) Fork ControllerManagerConfigurationSpec (#114)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.8.0](https://github.com/kubestash/cli/releases/tag/v0.8.0)
+
+- [9617d0a](https://github.com/kubestash/cli/commit/9617d0a) Prepare for release v0.8.0 (#31)
+- [c74e71f](https://github.com/kubestash/cli/commit/c74e71f) Use k8s 1.30 client libs (#30)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2024.6.4](https://github.com/kubestash/installer/releases/tag/v2024.6.4)
+
+- [ecf4de4](https://github.com/kubestash/installer/commit/ecf4de4) Prepare for release v2024.6.4 (#70)
+- [b42254a](https://github.com/kubestash/installer/commit/b42254a) Use k8s 1.30 client libs (#69)
+- [12f1da6](https://github.com/kubestash/installer/commit/12f1da6) Add manifest functions (#68)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.8.0](https://github.com/kubestash/kubedump/releases/tag/v0.8.0)
+
+- [f7ed5c1](https://github.com/kubestash/kubedump/commit/f7ed5c1) Prepare for release v0.8.0 (#25)
+- [2eccceb](https://github.com/kubestash/kubedump/commit/2eccceb) Use k8s 1.30 client libs (#24)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.9.0](https://github.com/kubestash/kubestash/releases/tag/v0.9.0)
+
+- [9619cf74](https://github.com/kubestash/kubestash/commit/9619cf74) Prepare for release v0.9.0 (#232)
+- [4f3854f8](https://github.com/kubestash/kubestash/commit/4f3854f8) Use k8s 1.30 client libs (#231)
+- [f04a4fa2](https://github.com/kubestash/kubestash/commit/f04a4fa2) Add support for workload manifest backup and restore (#229)
+- [1b876c7e](https://github.com/kubestash/kubestash/commit/1b876c7e) Rearrange addon tasks according to task name (#228)
+- [c8e91e1a](https://github.com/kubestash/kubestash/commit/c8e91e1a) Add validation for datasource components (#225)
+- [e56554f3](https://github.com/kubestash/kubestash/commit/e56554f3) Create RoleBinding in the manifest namespace (#227)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.1.0](https://github.com/kubestash/manifest/releases/tag/v0.1.0)
+
+- [4b71671](https://github.com/kubestash/manifest/commit/4b71671) Prepare for release v0.1.0 (#8)
+- [9fb9f49](https://github.com/kubestash/manifest/commit/9fb9f49) Use k8s 1.30 client libs (#7)
+- [addbde9](https://github.com/kubestash/manifest/commit/addbde9) Implement manifest addon (#6)
+- [caa1add](https://github.com/kubestash/manifest/commit/caa1add) Use Go 1.22 (#5)
+- [e814e7b](https://github.com/kubestash/manifest/commit/e814e7b) Use deps (#3)
+- [d56cd12](https://github.com/kubestash/manifest/commit/d56cd12) Use k8s 1.29 client libs (#2)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.8.0](https://github.com/kubestash/pvc/releases/tag/v0.8.0)
+
+- [79890f3](https://github.com/kubestash/pvc/commit/79890f3) Prepare for release v0.8.0 (#34)
+- [f77b8dc](https://github.com/kubestash/pvc/commit/f77b8dc) Use k8s 1.30 client libs (#33)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.8.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.8.0)
+
+- [d5299da7](https://github.com/kubestash/volume-snapshotter/commit/d5299da7) Prepare for release v0.8.0 (#29)
+- [efb4229a](https://github.com/kubestash/volume-snapshotter/commit/efb4229a) Use k8s 1.30 client libs (#28)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.8.0](https://github.com/kubestash/workload/releases/tag/v0.8.0)
+
+- [358f2c5](https://github.com/kubestash/workload/commit/358f2c5) Prepare for release v0.8.0 (#45)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2024.6.4
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/14
Signed-off-by: 1gtm <1gtm@appscode.com>