### PR TITLE
Prepare for release v2024.7.1

### DIFF
--- a/docs/CHANGELOG-v2024.7.1.md
+++ b/docs/CHANGELOG-v2024.7.1.md
@@ -1,0 +1,100 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2024.7.1
+    name: Changelog-v2024.7.1
+    parent: welcome
+    weight: 20240701
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.7.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.7.1/
+---
+
+# KubeStash v2024.7.1 (2024-07-01)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.10.0](https://github.com/kubestash/apimachinery/releases/tag/v0.10.0)
+
+- [c8297c38](https://github.com/kubestash/apimachinery/commit/c8297c38) Update deps
+- [7e9cb957](https://github.com/kubestash/apimachinery/commit/7e9cb957) Add `DisableContentTypeDetection` for s3proxy error (#118)
+- [d14e1b4b](https://github.com/kubestash/apimachinery/commit/d14e1b4b) Add necessary fields for separately retention policy applier (#111)
+- [aef4b1e7](https://github.com/kubestash/apimachinery/commit/aef4b1e7) Add gcloud-blobs package for cloud storage services (#115)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.9.0](https://github.com/kubestash/cli/releases/tag/v0.9.0)
+
+- [74b37f8](https://github.com/kubestash/cli/commit/74b37f8) Prepare for release v0.9.0 (#32)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2024.7.1](https://github.com/kubestash/installer/releases/tag/v2024.7.1)
+
+- [52560a3](https://github.com/kubestash/installer/commit/52560a3) Prepare for release v2024.7.1 (#72)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.9.0](https://github.com/kubestash/kubedump/releases/tag/v0.9.0)
+
+- [26a75f9](https://github.com/kubestash/kubedump/commit/26a75f9) Prepare for release v0.9.0 (#26)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.10.0](https://github.com/kubestash/kubestash/releases/tag/v0.10.0)
+
+- [50c37b1f](https://github.com/kubestash/kubestash/commit/50c37b1f) Prepare for release v0.10.0 (#236)
+- [2b62f295](https://github.com/kubestash/kubestash/commit/2b62f295) Fix to ignore `ContentType` for s3-proxy and driverFunctionMap nil pointer (#235)
+- [4b02e8cc](https://github.com/kubestash/kubestash/commit/4b02e8cc) Rework retention-policy execution (#230)
+- [298d7817](https://github.com/kubestash/kubestash/commit/298d7817) Allow `BackupStorage` deletion if backend secret not found (#226)
+- [232afedb](https://github.com/kubestash/kubestash/commit/232afedb) Move cloud blob package to api-machinery for global usages (#233)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.2.0](https://github.com/kubestash/manifest/releases/tag/v0.2.0)
+
+- [9a7d25c](https://github.com/kubestash/manifest/commit/9a7d25c) Prepare for release v0.2.0 (#9)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.9.0](https://github.com/kubestash/pvc/releases/tag/v0.9.0)
+
+- [1d3d587](https://github.com/kubestash/pvc/commit/1d3d587) Prepare for release v0.9.0 (#35)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.9.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.9.0)
+
+- [f547f1a8](https://github.com/kubestash/volume-snapshotter/commit/f547f1a8) Prepare for release v0.9.0 (#30)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.9.0](https://github.com/kubestash/workload/releases/tag/v0.9.0)
+
+- [63230c7](https://github.com/kubestash/workload/commit/63230c7) Prepare for release v0.9.0 (#46)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2024.7.1
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/15
Signed-off-by: 1gtm <1gtm@appscode.com>