### PR TITLE
Prepare for release v2024.8.14

### DIFF
--- a/docs/CHANGELOG-v2024.8.14.md
+++ b/docs/CHANGELOG-v2024.8.14.md
@@ -1,0 +1,101 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2024.8.14
+    name: Changelog-v2024.8.14
+    parent: welcome
+    weight: 20240814
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.8.14/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.8.14/
+---
+
+# KubeStash v2024.8.14 (2024-08-14)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.11.0](https://github.com/kubestash/apimachinery/releases/tag/v0.11.0)
+
+- [26444347](https://github.com/kubestash/apimachinery/commit/26444347) Use Go 1.23 (#125)
+- [9214357f](https://github.com/kubestash/apimachinery/commit/9214357f) Fix resolving Addon version (#121)
+- [058da7c8](https://github.com/kubestash/apimachinery/commit/058da7c8) Fix kubedb-crds import by removing kubedb apimachinery dependency (#123)
+- [fc473bf8](https://github.com/kubestash/apimachinery/commit/fc473bf8) Add MSSQLServer manifest restore options to restoresession (#120)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.10.0](https://github.com/kubestash/cli/releases/tag/v0.10.0)
+
+- [950ae09](https://github.com/kubestash/cli/commit/950ae09) Prepare for release v0.10.0 (#34)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2024.8.14](https://github.com/kubestash/installer/releases/tag/v2024.8.14)
+
+- [5ddcde9](https://github.com/kubestash/installer/commit/5ddcde9) Prepare for release v2024.8.14 (#79)
+- [d5bbc0b](https://github.com/kubestash/installer/commit/d5bbc0b) Test against k8s 1.31 (#77)
+- [279541d](https://github.com/kubestash/installer/commit/279541d) Add rbac permissions for MSSQL manifest backup, restore (#75)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.10.0](https://github.com/kubestash/kubedump/releases/tag/v0.10.0)
+
+- [3140b0a](https://github.com/kubestash/kubedump/commit/3140b0a) Prepare for release v0.10.0 (#28)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.11.0](https://github.com/kubestash/kubestash/releases/tag/v0.11.0)
+
+- [cbb2e18b](https://github.com/kubestash/kubestash/commit/cbb2e18b) Prepare for release v0.11.0 (#244)
+- [a59d5312](https://github.com/kubestash/kubestash/commit/a59d5312) Fix preferred resource version for target (#242)
+- [9ed4889b](https://github.com/kubestash/kubestash/commit/9ed4889b) Add necessary rbac permissions backup/restore job for MSSQLServer (#240)
+- [8af2c3de](https://github.com/kubestash/kubestash/commit/8af2c3de) Report control plane and worker node stats
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.3.0](https://github.com/kubestash/manifest/releases/tag/v0.3.0)
+
+- [b9c2b22](https://github.com/kubestash/manifest/commit/b9c2b22) Prepare for release v0.3.0 (#11)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.10.0](https://github.com/kubestash/pvc/releases/tag/v0.10.0)
+
+- [fca0e1b](https://github.com/kubestash/pvc/commit/fca0e1b) Prepare for release v0.10.0 (#37)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.10.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.10.0)
+
+- [ae38ec66](https://github.com/kubestash/volume-snapshotter/commit/ae38ec66) Prepare for release v0.10.0 (#32)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.10.0](https://github.com/kubestash/workload/releases/tag/v0.10.0)
+
+- [1e66749](https://github.com/kubestash/workload/commit/1e66749) Prepare for release v0.10.0 (#48)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2024.8.14
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/17
Signed-off-by: 1gtm <1gtm@appscode.com>