### PR TITLE
Prepare for release v2024.8.30

### DIFF
--- a/docs/CHANGELOG-v2024.8.30.md
+++ b/docs/CHANGELOG-v2024.8.30.md
@@ -1,0 +1,104 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2024.8.30
+    name: Changelog-v2024.8.30
+    parent: welcome
+    weight: 20240830
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.8.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.8.30/
+---
+
+# KubeStash v2024.8.30 (2024-08-30)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.12.0](https://github.com/kubestash/apimachinery/releases/tag/v0.12.0)
+
+- [5b2bd98f](https://github.com/kubestash/apimachinery/commit/5b2bd98f) Update deps
+- [56fa8e6a](https://github.com/kubestash/apimachinery/commit/56fa8e6a) Add constants for initial backup trigger (#127)
+- [1295e35b](https://github.com/kubestash/apimachinery/commit/1295e35b) Use Go 1.23 (#126)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.11.0](https://github.com/kubestash/cli/releases/tag/v0.11.0)
+
+- [7b8760e](https://github.com/kubestash/cli/commit/7b8760e) Prepare for release v0.11.0 (#35)
+- [e25615d](https://github.com/kubestash/cli/commit/e25615d) Use Go 1.23 (#33)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2024.8.30](https://github.com/kubestash/installer/releases/tag/v2024.8.30)
+
+- [e3b3047](https://github.com/kubestash/installer/commit/e3b3047) Prepare for release v2024.8.30 (#80)
+- [a77a8d3](https://github.com/kubestash/installer/commit/a77a8d3) Use Go 1.23 (#78)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.11.0](https://github.com/kubestash/kubedump/releases/tag/v0.11.0)
+
+- [4d6c846](https://github.com/kubestash/kubedump/commit/4d6c846) Prepare for release v0.11.0 (#29)
+- [b755b27](https://github.com/kubestash/kubedump/commit/b755b27) Use Go 1.23 (#27)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.12.0](https://github.com/kubestash/kubestash/releases/tag/v0.12.0)
+
+- [4ef5a4e0](https://github.com/kubestash/kubestash/commit/4ef5a4e0) Prepare for release v0.12.0 (#246)
+- [b5e5a908](https://github.com/kubestash/kubestash/commit/b5e5a908) Add support for trigger initial backup (#245)
+- [7fd8a1dd](https://github.com/kubestash/kubestash/commit/7fd8a1dd) Use Go 1.23 (#243)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.4.0](https://github.com/kubestash/manifest/releases/tag/v0.4.0)
+
+- [eeac8b6](https://github.com/kubestash/manifest/commit/eeac8b6) Prepare for release v0.4.0 (#12)
+- [d26c6c1](https://github.com/kubestash/manifest/commit/d26c6c1) Use Go 1.23 (#10)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.11.0](https://github.com/kubestash/pvc/releases/tag/v0.11.0)
+
+- [6a3ed4d](https://github.com/kubestash/pvc/commit/6a3ed4d) Prepare for release v0.11.0 (#38)
+- [585053c](https://github.com/kubestash/pvc/commit/585053c) Use Go 1.23 (#36)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.11.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.11.0)
+
+- [bab1f809](https://github.com/kubestash/volume-snapshotter/commit/bab1f809) Prepare for release v0.11.0 (#33)
+- [0cbb4f32](https://github.com/kubestash/volume-snapshotter/commit/0cbb4f32) Use Go 1.23 (#31)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.11.0](https://github.com/kubestash/workload/releases/tag/v0.11.0)
+
+- [769d7b5](https://github.com/kubestash/workload/commit/769d7b5) Prepare for release v0.11.0 (#49)
+- [3721e80](https://github.com/kubestash/workload/commit/3721e80) Use Go 1.23 (#47)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2024.8.30
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/19
Signed-off-by: 1gtm <1gtm@appscode.com>