### PR TITLE
Prepare for release v2024.12.9

### DIFF
--- a/docs/CHANGELOG-v2024.12.9.md
+++ b/docs/CHANGELOG-v2024.12.9.md
@@ -1,0 +1,132 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2024.12.9
+    name: Changelog-v2024.12.9
+    parent: welcome
+    weight: 20241209
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.12.9/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.12.9/
+---
+
+# KubeStash v2024.12.9 (2024-12-07)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.14.0](https://github.com/kubestash/apimachinery/releases/tag/v0.14.0)
+
+- [3af40bbe](https://github.com/kubestash/apimachinery/commit/3af40bbe) Update crds
+- [cb4e834f](https://github.com/kubestash/apimachinery/commit/cb4e834f) Removed InternalAuthIssuerRef from MSSQLServer Manifest Option (#141)
+- [212f57bd](https://github.com/kubestash/apimachinery/commit/212f57bd) Add backup verification apis (#116)
+- [35b1ce3f](https://github.com/kubestash/apimachinery/commit/35b1ce3f) Add redisSentinel options for manifest backup/restore (#139)
+- [50d8c6b6](https://github.com/kubestash/apimachinery/commit/50d8c6b6) Add start and end time for restic stats (#138)
+- [54ddea4f](https://github.com/kubestash/apimachinery/commit/54ddea4f) Replace manifest bool values to bool pointer (#137)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.13.0](https://github.com/kubestash/cli/releases/tag/v0.13.0)
+
+- [0adfa1b](https://github.com/kubestash/cli/commit/0adfa1b) Prepare for release v0.13.0 (#40)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2024.12.9](https://github.com/kubestash/installer/releases/tag/v2024.12.9)
+
+- [851b024](https://github.com/kubestash/installer/commit/851b024) Prepare for release v2024.12.9 (#120)
+- [bddf9f9](https://github.com/kubestash/installer/commit/bddf9f9) Check for image architecture (#119)
+- [f05d290](https://github.com/kubestash/installer/commit/f05d290) Update cve report (#118)
+- [f34bde9](https://github.com/kubestash/installer/commit/f34bde9) Update cve report (#117)
+- [00c179a](https://github.com/kubestash/installer/commit/00c179a) Update cve report (#116)
+- [967b667](https://github.com/kubestash/installer/commit/967b667) Update cve report (#115)
+- [5e47b4d](https://github.com/kubestash/installer/commit/5e47b4d) Update cve report (#114)
+- [ba3a88e](https://github.com/kubestash/installer/commit/ba3a88e) Update cve report (#113)
+- [2e78681](https://github.com/kubestash/installer/commit/2e78681) Update cve report (#112)
+- [2d8e32c](https://github.com/kubestash/installer/commit/2d8e32c) Use kind v0.25.0 (#111)
+- [d561f53](https://github.com/kubestash/installer/commit/d561f53) Update cve report (#110)
+- [c6433ec](https://github.com/kubestash/installer/commit/c6433ec) Update cve report (#109)
+- [b4547b0](https://github.com/kubestash/installer/commit/b4547b0) Update cve report (#108)
+- [72ed728](https://github.com/kubestash/installer/commit/72ed728) Update cve report (#107)
+- [5661159](https://github.com/kubestash/installer/commit/5661159) Update cve report (#106)
+- [64355b1](https://github.com/kubestash/installer/commit/64355b1) Update cve report (#105)
+- [ab4dcc3](https://github.com/kubestash/installer/commit/ab4dcc3) Update cve report (#104)
+- [db5165b](https://github.com/kubestash/installer/commit/db5165b) Update cve report (#103)
+- [2122619](https://github.com/kubestash/installer/commit/2122619) Update cve report (#102)
+- [cd4994f](https://github.com/kubestash/installer/commit/cd4994f) Update cve report (#101)
+- [c7a1d6d](https://github.com/kubestash/installer/commit/c7a1d6d) Update cve report (#100)
+- [c2646da](https://github.com/kubestash/installer/commit/c2646da) Update cve report (#99)
+- [a0aef87](https://github.com/kubestash/installer/commit/a0aef87) Update cve report (#98)
+- [ffd01eb](https://github.com/kubestash/installer/commit/ffd01eb) Update cve report (#97)
+- [2d17996](https://github.com/kubestash/installer/commit/2d17996) Update cve report (#96)
+- [6194319](https://github.com/kubestash/installer/commit/6194319) Update cve report (#95)
+- [573db73](https://github.com/kubestash/installer/commit/573db73) Update cve report (#94)
+- [46b766c](https://github.com/kubestash/installer/commit/46b766c) Update cve report (#93)
+- [3fead1b](https://github.com/kubestash/installer/commit/3fead1b) Update cve report (#92)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.13.0](https://github.com/kubestash/kubedump/releases/tag/v0.13.0)
+
+- [f303dce](https://github.com/kubestash/kubedump/commit/f303dce) Prepare for release v0.13.0 (#35)
+- [ab8c584](https://github.com/kubestash/kubedump/commit/ab8c584) Use debian:12 base image (#34)
+- [6f6ad4d](https://github.com/kubestash/kubedump/commit/6f6ad4d) Use debian:12 base image (#33)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.14.0](https://github.com/kubestash/kubestash/releases/tag/v0.14.0)
+
+- [f3f9694f](https://github.com/kubestash/kubestash/commit/f3f9694f) Prepare for release v0.14.0 (#266)
+- [ae5f187e](https://github.com/kubestash/kubestash/commit/ae5f187e) Add support for templating for exec hook command (#264)
+- [5587805a](https://github.com/kubestash/kubestash/commit/5587805a) Resolve DBversion for External Databases (#263)
+- [aae7247a](https://github.com/kubestash/kubestash/commit/aae7247a) Add support for backup verification (#234)
+- [e74509bd](https://github.com/kubestash/kubestash/commit/e74509bd) Fix upsertPodSpec for ensuring jobs (#261)
+- [7ed0d6b9](https://github.com/kubestash/kubestash/commit/7ed0d6b9) Use debian:12 base image (#262)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.13.0](https://github.com/kubestash/pvc/releases/tag/v0.13.0)
+
+- [d95ca55](https://github.com/kubestash/pvc/commit/d95ca55) Prepare for release v0.13.0 (#44)
+- [705ca8f](https://github.com/kubestash/pvc/commit/705ca8f) Use debian:12 base image (#43)
+- [818c691](https://github.com/kubestash/pvc/commit/818c691) Use debian:12 base image (#42)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.13.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.13.0)
+
+- [3de21473](https://github.com/kubestash/volume-snapshotter/commit/3de21473) Prepare for release v0.13.0 (#37)
+- [f1ae4e80](https://github.com/kubestash/volume-snapshotter/commit/f1ae4e80) Use debian:12 base image (#36)
+- [c6fe9854](https://github.com/kubestash/volume-snapshotter/commit/c6fe9854) Use debian:12 base image (#35)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.13.0](https://github.com/kubestash/workload/releases/tag/v0.13.0)
+
+- [eedd660](https://github.com/kubestash/workload/commit/eedd660) Prepare for release v0.13.0 (#54)
+- [7112586](https://github.com/kubestash/workload/commit/7112586) Build image for arm64
+- [7b67513](https://github.com/kubestash/workload/commit/7b67513) Use debian:12 base image (#53)
+- [d232d23](https://github.com/kubestash/workload/commit/d232d23) Use debian:12 base image (#52)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2024.12.9
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/21
Signed-off-by: 1gtm <1gtm@appscode.com>