### PR TITLE
Prepare for release v2025.1.9

### DIFF
--- a/docs/CHANGELOG-v2025.1.9.md
+++ b/docs/CHANGELOG-v2025.1.9.md
@@ -1,0 +1,109 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2025.1.9
+    name: Changelog-v2025.1.9
+    parent: welcome
+    weight: 20250109
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.1.9/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.1.9/
+---
+
+# KubeStash v2025.1.9 (2025-01-08)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.15.0](https://github.com/kubestash/apimachinery/releases/tag/v0.15.0)
+
+- [c6512dfa](https://github.com/kubestash/apimachinery/commit/c6512dfa) Use import hack for license-verifier pkg
+- [1e7268c3](https://github.com/kubestash/apimachinery/commit/1e7268c3) Fix patching
+- [a2fd1f02](https://github.com/kubestash/apimachinery/commit/a2fd1f02) Update github action modules (#146)
+- [8f481a8c](https://github.com/kubestash/apimachinery/commit/8f481a8c) Re-design WalStats field; Remove WalSegment (#142)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.14.0](https://github.com/kubestash/cli/releases/tag/v0.14.0)
+
+- [6730892](https://github.com/kubestash/cli/commit/6730892) Prepare for release v0.14.0 (#43)
+- [0f5f799](https://github.com/kubestash/cli/commit/0f5f799) Update github action modules (#41)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2025.1.9](https://github.com/kubestash/installer/releases/tag/v2025.1.9)
+
+- [df01150](https://github.com/kubestash/installer/commit/df01150) Prepare for release v2025.1.9 (#130)
+- [c909e8a](https://github.com/kubestash/installer/commit/c909e8a) Update github action modules (#129)
+- [8d2c4af](https://github.com/kubestash/installer/commit/8d2c4af) Update github action modules (#127)
+- [3ed4b9a](https://github.com/kubestash/installer/commit/3ed4b9a) Update cve report (#126)
+- [9cbabc8](https://github.com/kubestash/installer/commit/9cbabc8) Update cve report (#125)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.14.0](https://github.com/kubestash/kubedump/releases/tag/v0.14.0)
+
+- [5c5b91a](https://github.com/kubestash/kubedump/commit/5c5b91a) Prepare for release v0.14.0 (#37)
+- [047a7b2](https://github.com/kubestash/kubedump/commit/047a7b2) Update github action modules (#36)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.15.0](https://github.com/kubestash/kubestash/releases/tag/v0.15.0)
+
+- [3fd04d9e](https://github.com/kubestash/kubestash/commit/3fd04d9e) Prepare for release v0.15.0 (#270)
+- [673266f1](https://github.com/kubestash/kubestash/commit/673266f1) Update github action modules (#269)
+- [82f656a5](https://github.com/kubestash/kubestash/commit/82f656a5) Unset repo last snapshot time for incremental snapshot (#268)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.7.0](https://github.com/kubestash/manifest/releases/tag/v0.7.0)
+
+- [2ca622d](https://github.com/kubestash/manifest/commit/2ca622d) Prepare for release v0.7.0 (#21)
+- [033b237](https://github.com/kubestash/manifest/commit/033b237) Update github action modules (#20)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.14.0](https://github.com/kubestash/pvc/releases/tag/v0.14.0)
+
+- [8fe163f](https://github.com/kubestash/pvc/commit/8fe163f) Prepare for release v0.14.0 (#46)
+- [237b789](https://github.com/kubestash/pvc/commit/237b789) Update github action modules (#45)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.14.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.14.0)
+
+- [9c48535c](https://github.com/kubestash/volume-snapshotter/commit/9c48535c) Prepare for release v0.14.0 (#39)
+- [39fdce8b](https://github.com/kubestash/volume-snapshotter/commit/39fdce8b) Update github action modules (#38)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.14.0](https://github.com/kubestash/workload/releases/tag/v0.14.0)
+
+- [8a455d5](https://github.com/kubestash/workload/commit/8a455d5) Prepare for release v0.14.0 (#57)
+- [89cecd1](https://github.com/kubestash/workload/commit/89cecd1) Delete .github/workflows/cherry-pick.yml
+- [fd2c5ca](https://github.com/kubestash/workload/commit/fd2c5ca) Update github action modules (#55)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2025.1.9
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/23
Signed-off-by: 1gtm <1gtm@appscode.com>