### PR TITLE
Prepare for release v2025.4.30

### DIFF
--- a/docs/CHANGELOG-v2025.4.30.md
+++ b/docs/CHANGELOG-v2025.4.30.md
@@ -1,0 +1,106 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2025.4.30
+    name: Changelog-v2025.4.30
+    parent: welcome
+    weight: 20250430
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.4.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.4.30/
+---
+
+# KubeStash v2025.4.30 (2025-04-30)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.18.0](https://github.com/kubestash/apimachinery/releases/tag/v0.18.0)
+
+- [c762b940](https://github.com/kubestash/apimachinery/commit/c762b940) Update deps
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.17.0](https://github.com/kubestash/cli/releases/tag/v0.17.0)
+
+- [f3cc943b](https://github.com/kubestash/cli/commit/f3cc943b) Prepare for release v0.17.0 (#57)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2025.4.30](https://github.com/kubestash/installer/releases/tag/v2025.4.30)
+
+- [44e8a42](https://github.com/kubestash/installer/commit/44e8a42) Prepare for release v2025.4.30 (#182)
+- [dce6f44](https://github.com/kubestash/installer/commit/dce6f44) Update cve report (#181)
+- [274e5d1](https://github.com/kubestash/installer/commit/274e5d1) Update cve report (#180)
+- [acf1c9e](https://github.com/kubestash/installer/commit/acf1c9e) Update cve report (#179)
+- [4dc71e6](https://github.com/kubestash/installer/commit/4dc71e6) Add Workload manifest backup/restore params (#177)
+- [625229b](https://github.com/kubestash/installer/commit/625229b) Update cve report (#176)
+- [758f9e1](https://github.com/kubestash/installer/commit/758f9e1) Update cve report (#175)
+- [f10ffc4](https://github.com/kubestash/installer/commit/f10ffc4) Update cve report (#174)
+- [27e3544](https://github.com/kubestash/installer/commit/27e3544) Update cve report (#173)
+- [a32bb57](https://github.com/kubestash/installer/commit/a32bb57) Update cve report (#172)
+- [eff6fad](https://github.com/kubestash/installer/commit/eff6fad) Update cve report (#171)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.17.0](https://github.com/kubestash/kubedump/releases/tag/v0.17.0)
+
+- [4cd27ac](https://github.com/kubestash/kubedump/commit/4cd27ac) Prepare for release v0.17.0 (#48)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.18.0](https://github.com/kubestash/kubestash/releases/tag/v0.18.0)
+
+- [aea0db1d](https://github.com/kubestash/kubestash/commit/aea0db1d) Prepare for release v0.18.0 (#294)
+- [d5b23a62](https://github.com/kubestash/kubestash/commit/d5b23a62) Short replicaset for by creation timestamp (#292)
+- [de23a072](https://github.com/kubestash/kubestash/commit/de23a072) Fix only worload-manifest restore (#291)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.10.0](https://github.com/kubestash/manifest/releases/tag/v0.10.0)
+
+- [25bdd06](https://github.com/kubestash/manifest/commit/25bdd06) Prepare for release v0.10.0 (#34)
+- [1625f00](https://github.com/kubestash/manifest/commit/1625f00) backup & restoration support for workload (#27)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.17.0](https://github.com/kubestash/pvc/releases/tag/v0.17.0)
+
+- [d64db2e](https://github.com/kubestash/pvc/commit/d64db2e) Prepare for release v0.17.0 (#55)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.17.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.17.0)
+
+- [194fdcb5](https://github.com/kubestash/volume-snapshotter/commit/194fdcb5) Prepare for release v0.17.0 (#46)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.17.0](https://github.com/kubestash/workload/releases/tag/v0.17.0)
+
+- [d09bf03](https://github.com/kubestash/workload/commit/d09bf03) Prepare for release v0.17.0 (#66)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2025.4.30
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/30
Signed-off-by: 1gtm <1gtm@appscode.com>