### PR TITLE
Prepare for release v2025.6.30

### DIFF
--- a/docs/CHANGELOG-v2025.6.30.md
+++ b/docs/CHANGELOG-v2025.6.30.md
@@ -1,0 +1,114 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2025.6.30
+    name: Changelog-v2025.6.30
+    parent: welcome
+    weight: 20250630
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.6.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.6.30/
+---
+
+# KubeStash v2025.6.30 (2025-06-30)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.19.0](https://github.com/kubestash/apimachinery/releases/tag/v0.19.0)
+
+- [cc74f785](https://github.com/kubestash/apimachinery/commit/cc74f785) Update deps
+- [1422c5d1](https://github.com/kubestash/apimachinery/commit/1422c5d1) Report cluster mode with events (#165)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.18.0](https://github.com/kubestash/cli/releases/tag/v0.18.0)
+
+- [dbb83d48](https://github.com/kubestash/cli/commit/dbb83d48) Prepare for release v0.18.0 (#61)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2025.6.30](https://github.com/kubestash/installer/releases/tag/v2025.6.30)
+
+- [200b853](https://github.com/kubestash/installer/commit/200b853) Prepare for release v2025.6.30 (#198)
+- [9c79fa8](https://github.com/kubestash/installer/commit/9c79fa8) Add enableTaskQueue feature for taskqueue (#197)
+- [e4b372b](https://github.com/kubestash/installer/commit/e4b372b) Flags added for kubedump restore (#196)
+- [926a3d4](https://github.com/kubestash/installer/commit/926a3d4) Update cve report (#195)
+- [5b862ac](https://github.com/kubestash/installer/commit/5b862ac) Update cve report (#194)
+- [7848121](https://github.com/kubestash/installer/commit/7848121) Update cve report (#193)
+- [3272529](https://github.com/kubestash/installer/commit/3272529) Update cve report (#192)
+- [de08243](https://github.com/kubestash/installer/commit/de08243) Update cve report (#191)
+- [c9c7962](https://github.com/kubestash/installer/commit/c9c7962) Update cve report (#190)
+- [585e6ac](https://github.com/kubestash/installer/commit/585e6ac) Update cve report (#189)
+- [55d854a](https://github.com/kubestash/installer/commit/55d854a) Update cve report (#188)
+- [fdd11dd](https://github.com/kubestash/installer/commit/fdd11dd) Update cve report (#187)
+- [f190b7e](https://github.com/kubestash/installer/commit/f190b7e) Update cve report (#186)
+- [60d8425](https://github.com/kubestash/installer/commit/60d8425) Add include RBAC Resources (#185)
+- [19dcc76](https://github.com/kubestash/installer/commit/19dcc76) Update cve report (#184)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.18.0](https://github.com/kubestash/kubedump/releases/tag/v0.18.0)
+
+- [c94c2a6](https://github.com/kubestash/kubedump/commit/c94c2a6) Prepare for release v0.18.0 (#50)
+- [8575430](https://github.com/kubestash/kubedump/commit/8575430) Remove unnecessary sanitize flag (#49)
+- [1bfb140](https://github.com/kubestash/kubedump/commit/1bfb140) Add support for cluster restore functionality (#47)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.19.0](https://github.com/kubestash/kubestash/releases/tag/v0.19.0)
+
+- [6a283e3b](https://github.com/kubestash/kubestash/commit/6a283e3b) Prepare for release v0.19.0 (#298)
+- [efa4fa03](https://github.com/kubestash/kubestash/commit/efa4fa03) Add task queue feature for concurrent backupSessions  (#297)
+- [8d894576](https://github.com/kubestash/kubestash/commit/8d894576) Fix cleanup repo & storage (#296)
+- [04505144](https://github.com/kubestash/kubestash/commit/04505144) Do not default securityContext for dbs (#295)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.11.0](https://github.com/kubestash/manifest/releases/tag/v0.11.0)
+
+- [5e20494](https://github.com/kubestash/manifest/commit/5e20494) Prepare for release v0.11.0 (#35)
+- [7443c9c](https://github.com/kubestash/manifest/commit/7443c9c) Fixed restore namespace and added a flag for RBAC resources (#33)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.18.0](https://github.com/kubestash/pvc/releases/tag/v0.18.0)
+
+- [b890a36](https://github.com/kubestash/pvc/commit/b890a36) Prepare for release v0.18.0 (#56)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.18.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.18.0)
+
+- [eee38c74](https://github.com/kubestash/volume-snapshotter/commit/eee38c74) Prepare for release v0.18.0 (#47)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.18.0](https://github.com/kubestash/workload/releases/tag/v0.18.0)
+
+- [d49a1d2](https://github.com/kubestash/workload/commit/d49a1d2) Prepare for release v0.18.0 (#67)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2025.6.30
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/31
Signed-off-by: 1gtm <1gtm@appscode.com>