### PR TITLE
Prepare for release v2025.7.31

### DIFF
--- a/docs/CHANGELOG-v2025.7.31.md
+++ b/docs/CHANGELOG-v2025.7.31.md
@@ -1,0 +1,105 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2025.7.31
+    name: Changelog-v2025.7.31
+    parent: welcome
+    weight: 20250731
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.7.31/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.7.31/
+---
+
+# KubeStash v2025.7.31 (2025-08-07)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.20.0](https://github.com/kubestash/apimachinery/releases/tag/v0.20.0)
+
+- [a03678f9](https://github.com/kubestash/apimachinery/commit/a03678f9) Update deps
+- [696ac80f](https://github.com/kubestash/apimachinery/commit/696ac80f) Add resources filtering & sanitize packages (#169)
+- [a3e77398](https://github.com/kubestash/apimachinery/commit/a3e77398) Add Automatic Restic Unlock feature
+- [4032c43e](https://github.com/kubestash/apimachinery/commit/4032c43e) env variables set up for azure backend (#168)
+- [ecc14550](https://github.com/kubestash/apimachinery/commit/ecc14550) Update addon driver enum (#167)
+- [b8268a9e](https://github.com/kubestash/apimachinery/commit/b8268a9e) Add solr snapshot status (#119)
+- [46ae1e85](https://github.com/kubestash/apimachinery/commit/46ae1e85) Use external-snapshotter/client/v8 (#166)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.19.0](https://github.com/kubestash/cli/releases/tag/v0.19.0)
+
+- [674a6c8b](https://github.com/kubestash/cli/commit/674a6c8b) Prepare for release v0.19.0 (#62)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2025.7.31](https://github.com/kubestash/installer/releases/tag/v2025.7.31)
+
+- [dd32d71](https://github.com/kubestash/installer/commit/dd32d71) Prepare for release v2025.7.31 (#205)
+- [49f996f](https://github.com/kubestash/installer/commit/49f996f) Update cve report (#204)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.19.0](https://github.com/kubestash/kubedump/releases/tag/v0.19.0)
+
+- [4d9c805](https://github.com/kubestash/kubedump/commit/4d9c805) Prepare for release v0.19.0 (#55)
+- [0ca761d](https://github.com/kubestash/kubedump/commit/0ca761d) Owner reference issue fixed  (#54)
+- [e951e9c](https://github.com/kubestash/kubedump/commit/e951e9c) resource filtering parameter fix (#52)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.20.0](https://github.com/kubestash/kubestash/releases/tag/v0.20.0)
+
+- [c781e73c](https://github.com/kubestash/kubestash/commit/c781e73c) Prepare for release v0.20.0 (#299)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.12.0](https://github.com/kubestash/manifest/releases/tag/v0.12.0)
+
+- [e81db9f](https://github.com/kubestash/manifest/commit/e81db9f) Prepare for release v0.12.0 (#37)
+- [b1884cd](https://github.com/kubestash/manifest/commit/b1884cd) restic auto unlock feature added (#36)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.19.0](https://github.com/kubestash/pvc/releases/tag/v0.19.0)
+
+- [83e2b12](https://github.com/kubestash/pvc/commit/83e2b12) Prepare for release v0.19.0 (#58)
+- [22f566b](https://github.com/kubestash/pvc/commit/22f566b) Add Automatic Restic Unlock feature (#57)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.19.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.19.0)
+
+- [4c5a9b38](https://github.com/kubestash/volume-snapshotter/commit/4c5a9b38) Prepare for release v0.19.0 (#48)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.19.0](https://github.com/kubestash/workload/releases/tag/v0.19.0)
+
+- [08e05b7](https://github.com/kubestash/workload/commit/08e05b7) Prepare for release v0.19.0 (#69)
+- [3f58e28](https://github.com/kubestash/workload/commit/3f58e28) Add Automatic Restic Unlock feature (#68)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2025.7.31
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/32
Signed-off-by: 1gtm <1gtm@appscode.com>