### PR TITLE
Prepare for release v2026.2.28

### DIFF
--- a/docs/CHANGELOG-v2026.2.28.md
+++ b/docs/CHANGELOG-v2026.2.28.md
@@ -1,0 +1,93 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2026.2.28
+    name: Changelog-v2026.2.28
+    parent: welcome
+    weight: 20260228
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.2.28/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.2.28/
+---
+
+# KubeStash v2026.2.28 (2026-02-26)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.25.0](https://github.com/kubestash/apimachinery/releases/tag/v0.25.0)
+
+- [5bff2e6e](https://github.com/kubestash/apimachinery/commit/5bff2e6e) Use gomodules.xyz/restic v0.2.0 (#210)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.24.0](https://github.com/kubestash/cli/releases/tag/v0.24.0)
+
+- [3e380564](https://github.com/kubestash/cli/commit/3e380564) Prepare for release v0.24.0 (#81)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2026.2.28](https://github.com/kubestash/installer/releases/tag/v2026.2.28)
+
+- [4a33150](https://github.com/kubestash/installer/commit/4a33150) Prepare for release v2026.2.28 (#298)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.24.0](https://github.com/kubestash/kubedump/releases/tag/v0.24.0)
+
+- [2dbd9124](https://github.com/kubestash/kubedump/commit/2dbd9124) Prepare for release v0.24.0 (#81)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.25.0](https://github.com/kubestash/kubestash/releases/tag/v0.25.0)
+
+- [61976827](https://github.com/kubestash/kubestash/commit/61976827) Prepare for release v0.25.0 (#339)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.17.0](https://github.com/kubestash/manifest/releases/tag/v0.17.0)
+
+- [bc984261](https://github.com/kubestash/manifest/commit/bc984261) Prepare for release v0.17.0 (#59)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.24.0](https://github.com/kubestash/pvc/releases/tag/v0.24.0)
+
+- [314db0f3](https://github.com/kubestash/pvc/commit/314db0f3) Prepare for release v0.24.0 (#80)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.24.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.24.0)
+
+- [edee9925](https://github.com/kubestash/volume-snapshotter/commit/edee9925) Prepare for release v0.24.0 (#70)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.24.0](https://github.com/kubestash/workload/releases/tag/v0.24.0)
+
+- [de5b55dc](https://github.com/kubestash/workload/commit/de5b55dc) Prepare for release v0.24.0 (#90)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2026.2.28
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/42
Signed-off-by: 1gtm <1gtm@appscode.com>