### PR TITLE
Prepare for release v2026.2.26

### DIFF
--- a/docs/CHANGELOG-v2026.2.26.md
+++ b/docs/CHANGELOG-v2026.2.26.md
@@ -1,0 +1,103 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2026.2.26
+    name: Changelog-v2026.2.26
+    parent: welcome
+    weight: 20260226
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.2.26/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.2.26/
+---
+
+# KubeStash v2026.2.26 (2026-02-26)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.26.0](https://github.com/kubestash/apimachinery/releases/tag/v0.26.0)
+
+- [a7575b18](https://github.com/kubestash/apimachinery/commit/a7575b18) Update deps
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.25.0](https://github.com/kubestash/cli/releases/tag/v0.25.0)
+
+- [d78f06e0](https://github.com/kubestash/cli/commit/d78f06e0) Prepare for release v0.25.0 (#82)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2026.2.26](https://github.com/kubestash/installer/releases/tag/v2026.2.26)
+
+- [9a556ac](https://github.com/kubestash/installer/commit/9a556ac) Prepare for release v2026.2.26 (#299)
+- [4a33150](https://github.com/kubestash/installer/commit/4a33150) Prepare for release v2026.2.28 (#298)
+- [d94a613](https://github.com/kubestash/installer/commit/d94a613) Prepare for release v2026.2.27 (#297)
+- [0fd942c](https://github.com/kubestash/installer/commit/0fd942c) Add permission to report features in site info (#296)
+- [b4d6f04](https://github.com/kubestash/installer/commit/b4d6f04) Update cve report (#295)
+- [e114ef7](https://github.com/kubestash/installer/commit/e114ef7) Update cve report (#294)
+- [60e5c76](https://github.com/kubestash/installer/commit/60e5c76) Update cve report (#293)
+- [184bb50](https://github.com/kubestash/installer/commit/184bb50) Prepare for release v2026.2.16-rc.0 (#292)
+- [0cb552b](https://github.com/kubestash/installer/commit/0cb552b) Update cve report (#291)
+- [6e0e180](https://github.com/kubestash/installer/commit/6e0e180) Update cve report (#290)
+- [f4f22fc](https://github.com/kubestash/installer/commit/f4f22fc) Update cve report (#289)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.25.0](https://github.com/kubestash/kubedump/releases/tag/v0.25.0)
+
+- [32c60751](https://github.com/kubestash/kubedump/commit/32c60751) Prepare for release v0.25.0 (#82)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.26.0](https://github.com/kubestash/kubestash/releases/tag/v0.26.0)
+
+- [b3dd621b](https://github.com/kubestash/kubestash/commit/b3dd621b) Prepare for release v0.26.0 (#340)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.18.0](https://github.com/kubestash/manifest/releases/tag/v0.18.0)
+
+- [c11113d4](https://github.com/kubestash/manifest/commit/c11113d4) Prepare for release v0.18.0 (#60)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.25.0](https://github.com/kubestash/pvc/releases/tag/v0.25.0)
+
+- [d5165282](https://github.com/kubestash/pvc/commit/d5165282) Prepare for release v0.25.0 (#81)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.25.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.25.0)
+
+- [87e8c735](https://github.com/kubestash/volume-snapshotter/commit/87e8c735) Prepare for release v0.25.0 (#71)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.25.0](https://github.com/kubestash/workload/releases/tag/v0.25.0)
+
+- [1b3411d2](https://github.com/kubestash/workload/commit/1b3411d2) Prepare for release v0.25.0 (#91)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2026.2.26
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/43
Signed-off-by: 1gtm <1gtm@appscode.com>