### PR TITLE
Prepare for release v2026.5.18-rc.0

### DIFF
--- a/docs/CHANGELOG-v2026.5.18-rc.0.md
+++ b/docs/CHANGELOG-v2026.5.18-rc.0.md
@@ -1,0 +1,147 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2026.5.18-rc.0
+    name: Changelog-v2026.5.18-rc.0
+    parent: welcome
+    weight: 20260518
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.5.18-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.5.18-rc.0/
+---
+
+# KubeStash v2026.5.18-rc.0 (2026-05-19)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.28.0-rc.0](https://github.com/kubestash/apimachinery/releases/tag/v0.28.0-rc.0)
+
+- [54445516](https://github.com/kubestash/apimachinery/commit/54445516) Add AGENTS.md (#237)
+- [41bc2438](https://github.com/kubestash/apimachinery/commit/41bc2438) Harden CI workflows (#235)
+- [a8c23c8d](https://github.com/kubestash/apimachinery/commit/a8c23c8d) Add wal backup support for azure credless mode (#229)
+- [15ef11cd](https://github.com/kubestash/apimachinery/commit/15ef11cd) Bug fix for AzureFederatedTokenFile check (#228)
+- [81617867](https://github.com/kubestash/apimachinery/commit/81617867) Configure dependabot refresh schedule (#227)
+- [df6625c5](https://github.com/kubestash/apimachinery/commit/df6625c5) Cleanup CVEs
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.27.0-rc.0](https://github.com/kubestash/cli/releases/tag/v0.27.0-rc.0)
+
+- [3cb9e0ea](https://github.com/kubestash/cli/commit/3cb9e0ea) Prepare for release v0.27.0-rc.0 (#96)
+- [e3829bc2](https://github.com/kubestash/cli/commit/e3829bc2) Add CLAUDE.md pointing to AGENTS.md
+- [efe6839d](https://github.com/kubestash/cli/commit/efe6839d) Add AGENTS.md (#95)
+- [c54281f7](https://github.com/kubestash/cli/commit/c54281f7) Harden CI workflows (#94)
+- [afd774ae](https://github.com/kubestash/cli/commit/afd774ae) Prepare for release v0.26.0 (#92)
+- [818f5b5b](https://github.com/kubestash/cli/commit/818f5b5b) Bump RESTIC_VERSION to 0.18.1-20260421 (#91)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2026.5.18-rc.0](https://github.com/kubestash/installer/releases/tag/v2026.5.18-rc.0)
+
+- [6453c9d](https://github.com/kubestash/installer/commit/6453c9d) Prepare for release v2026.5.18-rc.0 (#345)
+- [179c8de](https://github.com/kubestash/installer/commit/179c8de) Add CLAUDE.md pointing to AGENTS.md
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.27.0-rc.0](https://github.com/kubestash/kubedump/releases/tag/v0.27.0-rc.0)
+
+- [813646cd](https://github.com/kubestash/kubedump/commit/813646cd) Prepare for release v0.27.0-rc.0 (#91)
+- [74c76a73](https://github.com/kubestash/kubedump/commit/74c76a73) Add CLAUDE.md pointing to AGENTS.md
+- [c80250fd](https://github.com/kubestash/kubedump/commit/c80250fd) Add AGENTS.md (#90)
+- [15603b29](https://github.com/kubestash/kubedump/commit/15603b29) Harden CI workflows (#89)
+- [1ad012f3](https://github.com/kubestash/kubedump/commit/1ad012f3) Prepare for release v0.26.0 (#87)
+- [8070801d](https://github.com/kubestash/kubedump/commit/8070801d) Bump RESTIC_VERSION to 0.18.1-20260421 (#86)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.28.0-rc.0](https://github.com/kubestash/kubestash/releases/tag/v0.28.0-rc.0)
+
+- [d4f0312f](https://github.com/kubestash/kubestash/commit/d4f0312f) Prepare for release v0.28.0-rc.0 (#361)
+- [dc81c8ab](https://github.com/kubestash/kubestash/commit/dc81c8ab) Add CLAUDE.md pointing to AGENTS.md
+- [2a4c7d2f](https://github.com/kubestash/kubestash/commit/2a4c7d2f) Add AGENTS.md (#360)
+- [dcbb855f](https://github.com/kubestash/kubestash/commit/dcbb855f) Harden CI workflows (#359)
+- [c6e91ff7](https://github.com/kubestash/kubestash/commit/c6e91ff7) Give RBAC Permission for Vault (#356)
+- [e1f0ea20](https://github.com/kubestash/kubestash/commit/e1f0ea20) Prepare for release v0.27.0 (#355)
+- [293d9ee8](https://github.com/kubestash/kubestash/commit/293d9ee8) Bump RESTIC_VERSION to 0.18.1-20260421 (#354)
+- [1cb336cd](https://github.com/kubestash/kubestash/commit/1cb336cd) Set Condition if retention policy Job failed (#353)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.20.0-rc.0](https://github.com/kubestash/manifest/releases/tag/v0.20.0-rc.0)
+
+- [5a77d020](https://github.com/kubestash/manifest/commit/5a77d020) Prepare for release v0.20.0-rc.0 (#69)
+- [6ab52d94](https://github.com/kubestash/manifest/commit/6ab52d94) Add CLAUDE.md pointing to AGENTS.md
+- [6a59c1db](https://github.com/kubestash/manifest/commit/6a59c1db) Add AGENTS.md (#68)
+- [624ce1be](https://github.com/kubestash/manifest/commit/624ce1be) Harden CI workflows (#67)
+- [ea51d5ed](https://github.com/kubestash/manifest/commit/ea51d5ed) Prepare for release v0.19.0 (#65)
+- [2d51179e](https://github.com/kubestash/manifest/commit/2d51179e) Bump RESTIC_VERSION to 0.18.1-20260421 (#64)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.27.0-rc.0](https://github.com/kubestash/pvc/releases/tag/v0.27.0-rc.0)
+
+- [f8085237](https://github.com/kubestash/pvc/commit/f8085237) Prepare for release v0.27.0-rc.0 (#92)
+- [4a75a698](https://github.com/kubestash/pvc/commit/4a75a698) Add CLAUDE.md pointing to AGENTS.md
+- [5a5ac911](https://github.com/kubestash/pvc/commit/5a5ac911) Add AGENTS.md (#91)
+- [c653a576](https://github.com/kubestash/pvc/commit/c653a576) Harden CI workflows (#90)
+- [53a4a0e9](https://github.com/kubestash/pvc/commit/53a4a0e9) Prepare for release v0.26.0 (#87)
+- [f84c778f](https://github.com/kubestash/pvc/commit/f84c778f) Bump RESTIC_VERSION to 0.18.1-20260421 (#86)
+
+
+
+## [kubestash/vault](https://github.com/kubestash/vault)
+
+### [v0.2.0-rc.0](https://github.com/kubestash/vault/releases/tag/v0.2.0-rc.0)
+
+- [5a75c93](https://github.com/kubestash/vault/commit/5a75c93) Prepare for release v0.2.0-rc.0 (#9)
+- [87ff5ea](https://github.com/kubestash/vault/commit/87ff5ea) Harden CI workflows (#8)
+- [32c3c24](https://github.com/kubestash/vault/commit/32c3c24) Fix docker Entrypoint
+- [9e64034](https://github.com/kubestash/vault/commit/9e64034) Prepare for release v0.1.0 (#6)
+- [0d0b854](https://github.com/kubestash/vault/commit/0d0b854) Bump RESTIC_VERSION to 0.18.1-20260421 (#5)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.27.0-rc.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.27.0-rc.0)
+
+- [d970b2d0](https://github.com/kubestash/volume-snapshotter/commit/d970b2d0) Prepare for release v0.27.0-rc.0 (#77)
+- [abfaa512](https://github.com/kubestash/volume-snapshotter/commit/abfaa512) Add CLAUDE.md pointing to AGENTS.md
+- [43682b88](https://github.com/kubestash/volume-snapshotter/commit/43682b88) Add AGENTS.md (#76)
+- [2f5685aa](https://github.com/kubestash/volume-snapshotter/commit/2f5685aa) Harden CI workflows (#75)
+- [a15200f3](https://github.com/kubestash/volume-snapshotter/commit/a15200f3) Prepare for release v0.26.0 (#73)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.27.0-rc.0](https://github.com/kubestash/workload/releases/tag/v0.27.0-rc.0)
+
+- [e7622298](https://github.com/kubestash/workload/commit/e7622298) Prepare for release v0.27.0-rc.0 (#100)
+- [6d56a144](https://github.com/kubestash/workload/commit/6d56a144) Add CLAUDE.md pointing to AGENTS.md
+- [03cc19e7](https://github.com/kubestash/workload/commit/03cc19e7) Add AGENTS.md (#99)
+- [1cd1314d](https://github.com/kubestash/workload/commit/1cd1314d) Harden CI workflows (#98)
+- [124338d3](https://github.com/kubestash/workload/commit/124338d3) Prepare for release v0.26.0 (#96)
+- [f5f20801](https://github.com/kubestash/workload/commit/f5f20801) Bump RESTIC_VERSION to 0.18.1-20260421 (#95)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2026.5.18-rc.0
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/49
Signed-off-by: 1gtm <1gtm@appscode.com>