### PR TITLE
Document Complete Transaction History with Point-in-Time Recovery

### DIFF
--- a/docs/concepts/capabilities/complete-transaction-history-pitr/index.md
+++ b/docs/concepts/capabilities/complete-transaction-history-pitr/index.md
@@ -1,0 +1,25 @@
+---
+title: Complete Transaction History with Point-in-Time Recovery
+description: Complete transaction history database with point-in-time recovery (PITR) to any second.
+menu:
+  docs_{{ .version }}:
+    identifier: capabilities-complete-transaction-history-pitr
+    name: Complete Transaction History with Point-in-Time Recovery
+    parent: capabilities
+    weight: 60
+product_name: kubestash
+menu_name: docs_{{ .version }}
+section_menu_id: concepts
+---
+
+# Complete Transaction History with Point-in-Time Recovery
+
+KubeStash maintains a complete transaction history database for supported engines (PostgreSQL, MySQL, MongoDB, and equivalents) by continuously archiving WAL, binlog, and engine-equivalent transaction logs. Combined with periodic base snapshots, this enables Point-in-Time Recovery (PITR) to any second within the retention window. The transaction log archive itself is the complete, queryable transaction history of record, which satisfies audit and regulatory requirements for transaction-level traceability without standing up a separate CDC pipeline.
+
+## Related concepts
+
+- [BackupConfiguration](../../crds/backupconfiguration/)
+- [BackupBlueprint](../../crds/backupblueprint/)
+- [RestoreSession](../../crds/restoresession/)
+- [RetentionPolicy](../../crds/retentionpolicy/)
+- [BackupVerifier](../../crds/backupverifier/)

--- a/docs/concepts/what-is-kubestash/overview/index.md
+++ b/docs/concepts/what-is-kubestash/overview/index.md
@@ -37,3 +37,4 @@ section_menu_id: concepts
 | Auto Backup                                                                             | Share backup configuration across workloads using templates. Enable backup for a target application via annotation.                    | 
 | Point-In-Time Recovery (PITR)                                                           | Restore a set of files from a time in the past.                                                                                        |
 | Role Based Access Control (RBAC)                                                        |                                                                                                                                        |
+| Complete Transaction History with Point-in-Time Recovery                                | Complete transaction history via continuous WAL / binlog archiving. Point-in-Time Recovery (PITR) to any second within the retention window. |


### PR DESCRIPTION
Documents the **Complete Transaction History with Point-in-Time Recovery** capability in the KubeStash docs.

What's added:
- A new row in the Features table at `docs/concepts/what-is-kubestash/overview/index.md`.
- A new in-depth page at `docs/concepts/capabilities/complete-transaction-history-pitr/index.md`.
- (First PR in the series only) A new section index at `docs/concepts/capabilities/_index.md`.

Companion PR in [kubestash/website](https://github.com/kubestash/website) is open on the same branch name.