### PR TITLE
Prepare for release v2026.6.18-rc.2

### DIFF
--- a/docs/CHANGELOG-v2026.6.18-rc.2.md
+++ b/docs/CHANGELOG-v2026.6.18-rc.2.md
@@ -1,0 +1,117 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2026.6.18-rc.2
+    name: Changelog-v2026.6.18-rc.2
+    parent: welcome
+    weight: 20260618
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.6.18-rc.2/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.6.18-rc.2/
+---
+
+# KubeStash v2026.6.18-rc.2 (2026-06-18)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.28.0-rc.2](https://github.com/kubestash/apimachinery/releases/tag/v0.28.0-rc.2)
+
+- [d4ad6ef7](https://github.com/kubestash/apimachinery/commit/d4ad6ef7) Snapshot/Restoresession Failed if one component Failed (#243)
+- [f0e134f9](https://github.com/kubestash/apimachinery/commit/f0e134f9) Add Progress structure in snapshot & restoresession status (#232)
+- [f6141bc6](https://github.com/kubestash/apimachinery/commit/f6141bc6) Bump go.bytebuilders.dev/audit to v0.0.52 (#241)
+- [6f7a74e0](https://github.com/kubestash/apimachinery/commit/6f7a74e0) Update go.bytebuilders.dev/audit to v0.0.51 (#240)
+- [165cb08b](https://github.com/kubestash/apimachinery/commit/165cb08b) Add Stream Reader for Download & Upload (#239)
+- [1d30072d](https://github.com/kubestash/apimachinery/commit/1d30072d) Add ClickHouse Manifest (#233)
+- [d5787deb](https://github.com/kubestash/apimachinery/commit/d5787deb) Add CLAUDE.md pointing to AGENTS.md
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.27.0-rc.2](https://github.com/kubestash/cli/releases/tag/v0.27.0-rc.2)
+
+- [97061afe](https://github.com/kubestash/cli/commit/97061afe) Prepare for release v0.27.0-rc.2 (#97)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2026.6.18-rc.2](https://github.com/kubestash/installer/releases/tag/v2026.6.18-rc.2)
+
+- [4371fb6](https://github.com/kubestash/installer/commit/4371fb6) Prepare for release v2026.6.18-rc.2 (#349)
+- [f2c3b1c](https://github.com/kubestash/installer/commit/f2c3b1c) Use ace-user-roles v2026.6.12 with audit cluster role (#347)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.27.0-rc.2](https://github.com/kubestash/kubedump/releases/tag/v0.27.0-rc.2)
+
+- [a87ce1d7](https://github.com/kubestash/kubedump/commit/a87ce1d7) Prepare for release v0.27.0-rc.2 (#96)
+- [3c5bec08](https://github.com/kubestash/kubedump/commit/3c5bec08) Add Backup & Restore Progress Streaming (#95)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.28.0-rc.2](https://github.com/kubestash/kubestash/releases/tag/v0.28.0-rc.2)
+
+- [8b46cb0f](https://github.com/kubestash/kubestash/commit/8b46cb0f) Prepare for release v0.28.0-rc.2 (#370)
+- [75e18ed2](https://github.com/kubestash/kubestash/commit/75e18ed2) Fix Restic Repository Integrity Issue Skylotec (#369)
+- [7fe53c55](https://github.com/kubestash/kubestash/commit/7fe53c55) Incorporate with API changes (#368)
+- [5f80e378](https://github.com/kubestash/kubestash/commit/5f80e378) Pin openshift-preflight version in release workflow (#365)
+- [78e9dc7c](https://github.com/kubestash/kubestash/commit/78e9dc7c) Document why Dockerfile.dbg keeps root user (#367)
+- [9be833f1](https://github.com/kubestash/kubestash/commit/9be833f1) Remove duplicate NewCmdDownload registration (#363)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.20.0-rc.2](https://github.com/kubestash/manifest/releases/tag/v0.20.0-rc.2)
+
+- [8e1922f1](https://github.com/kubestash/manifest/commit/8e1922f1) Prepare for release v0.20.0-rc.2 (#72)
+- [6b66a2e4](https://github.com/kubestash/manifest/commit/6b66a2e4) Add Backup & Restore Progress Streaming (#71)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.27.0-rc.2](https://github.com/kubestash/pvc/releases/tag/v0.27.0-rc.2)
+
+- [5401cafc](https://github.com/kubestash/pvc/commit/5401cafc) Prepare for release v0.27.0-rc.2 (#93)
+- [7d35b81d](https://github.com/kubestash/pvc/commit/7d35b81d) Add Backup & Restore Progress Streaming (#88)
+
+
+
+## [kubestash/vault](https://github.com/kubestash/vault)
+
+### [v0.2.0-rc.2](https://github.com/kubestash/vault/releases/tag/v0.2.0-rc.2)
+
+- [38fecc1](https://github.com/kubestash/vault/commit/38fecc1) Prepare for release v0.2.0-rc.2 (#10)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.27.0-rc.2](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.27.0-rc.2)
+
+- [ab5a5de7](https://github.com/kubestash/volume-snapshotter/commit/ab5a5de7) Prepare for release v0.27.0-rc.2 (#78)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.27.0-rc.2](https://github.com/kubestash/workload/releases/tag/v0.27.0-rc.2)
+
+- [3d571a3d](https://github.com/kubestash/workload/commit/3d571a3d) Prepare for release v0.27.0-rc.2 (#104)
+- [2488fbb7](https://github.com/kubestash/workload/commit/2488fbb7) Add Backup & Restore Progress Streaming (#103)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2026.6.18-rc.2
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/51
Signed-off-by: 1gtm <1gtm@appscode.com>