### PR TITLE
Make link checker resilient to transient external failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Check links
         run: |
-          lychee --root-dir $(pwd) --max-concurrency 10 --exclude '^(.*/docs/\{\{<.*>\}\}/.*|.*github.com.*|.*api.slack.com.*|.*askapache.com.*|.*twitter.com.*|.*dev.mysql.com.*|.*linux.die.net.*|.*helm.sh.*|.*aws.amazon.com.*|.*kind.sigs.k8s.io.*|.*git.k8s.io.*|.*localhost.*|.*kubedb.com.*)$' 'docs/**/*.md'
+          lychee --root-dir $(pwd) --max-concurrency 4 --max-retries 6 --retry-wait-time 5 --timeout 30 --exclude '^(.*/docs/\{\{<.*>\}\}/.*|.*github.com.*|.*api.slack.com.*|.*askapache.com.*|.*twitter.com.*|.*dev.mysql.com.*|.*linux.die.net.*|.*helm.sh.*|.*aws.amazon.com.*|.*kind.sigs.k8s.io.*|.*git.k8s.io.*|.*localhost.*|.*kubedb.com.*)$' 'docs/**/*.md'
 
       - name: Create Kubernetes cluster
         id: kind


### PR DESCRIPTION
## Problem

Master CI intermittently failed on the `Check links` step with:

```
[ERROR] https://kubernetes.io/... | Connection failed. Check network connectivity and firewall settings
```

The reported URLs are actually valid (HTTP 200). The failing set rotated run-to-run and the same commits passed on re-run — classic transient flakiness. `kubernetes.io` was intermittently rate-limiting / refusing connections from the runner, which hit external sites at concurrency 10 with **no retries**.

## Fix

Tune the lychee invocation:
- `--max-concurrency` 10 → **4** (less aggressive, avoids rate-limit triggers)
- `--max-retries 6` — retry transient failures instead of failing the build
- `--retry-wait-time 5` — back off between retries
- `--timeout 30` — tolerate slow responses

Verified locally with lychee v0.24.2 and the new flags: `0 Errors`.