### PR TITLE
Prepare for release v2026.7.10

### DIFF
--- a/docs/CHANGELOG-v2026.7.10.md
+++ b/docs/CHANGELOG-v2026.7.10.md
@@ -1,0 +1,107 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2026.7.10
+    name: Changelog-v2026.7.10
+    parent: welcome
+    weight: 20260710
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.7.10/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.7.10/
+---
+
+# KubeStash v2026.7.10 (2026-07-11)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.29.0](https://github.com/kubestash/apimachinery/releases/tag/v0.29.0)
+
+- [9675b635](https://github.com/kubestash/apimachinery/commit/9675b635) Update Restic Tag: v0.5.0 (#248)
+- [1f4a1713](https://github.com/kubestash/apimachinery/commit/1f4a1713) preserve false bool values in Neo4jStats backup inspect output (#245)
+- [0228bff3](https://github.com/kubestash/apimachinery/commit/0228bff3) Add LocalBackendPVC checker (#247)
+- [814aea8a](https://github.com/kubestash/apimachinery/commit/814aea8a) Update Dependency (#244)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.28.0](https://github.com/kubestash/cli/releases/tag/v0.28.0)
+
+- [312808c7](https://github.com/kubestash/cli/commit/312808c7) Prepare for release v0.28.0 (#104)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2026.7.10](https://github.com/kubestash/installer/releases/tag/v2026.7.10)
+
+- [2d9f7c7](https://github.com/kubestash/installer/commit/2d9f7c7) Prepare for release v2026.7.10 (#353)
+- [380d4ae](https://github.com/kubestash/installer/commit/380d4ae) Document regenerating the -certified charts in AGENTS.md (#352)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.28.0](https://github.com/kubestash/kubedump/releases/tag/v0.28.0)
+
+- [b5b949ec](https://github.com/kubestash/kubedump/commit/b5b949ec) Prepare for release v0.28.0 (#98)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.29.0](https://github.com/kubestash/kubestash/releases/tag/v0.29.0)
+
+- [bede1df9](https://github.com/kubestash/kubestash/commit/bede1df9) Prepare for release v0.29.0 (#377)
+- [95bc2d66](https://github.com/kubestash/kubestash/commit/95bc2d66) Fix postRestore OnSuccess executionPolicy check (#375)
+- [e561d6c6](https://github.com/kubestash/kubestash/commit/e561d6c6) Parse hook pod selector with labels.Parse (#366)
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.21.0](https://github.com/kubestash/manifest/releases/tag/v0.21.0)
+
+- [fb48d54f](https://github.com/kubestash/manifest/commit/fb48d54f) Prepare for release v0.21.0 (#74)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.28.0](https://github.com/kubestash/pvc/releases/tag/v0.28.0)
+
+- [9adaa5ec](https://github.com/kubestash/pvc/commit/9adaa5ec) Prepare for release v0.28.0 (#95)
+
+
+
+## [kubestash/vault](https://github.com/kubestash/vault)
+
+### [v0.3.0](https://github.com/kubestash/vault/releases/tag/v0.3.0)
+
+- [a7327f6](https://github.com/kubestash/vault/commit/a7327f6) Prepare for release v0.3.0 (#12)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.28.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.28.0)
+
+- [7697141b](https://github.com/kubestash/volume-snapshotter/commit/7697141b) Prepare for release v0.28.0 (#80)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.28.0](https://github.com/kubestash/workload/releases/tag/v0.28.0)
+
+- [81650277](https://github.com/kubestash/workload/commit/81650277) Prepare for release v0.28.0 (#106)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2026.7.10
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/53
Signed-off-by: 1gtm <1gtm@appscode.com>