### PR TITLE
docs(install): add Get a Free License section to install methods

### DIFF
--- a/docs/setup/install/kubestash/helm.md
+++ b/docs/setup/install/kubestash/helm.md
@@ -16,6 +16,10 @@ section_menu_id: setup
 
 KubeStash can be installed via [Helm](https://helm.sh/) using the [chart](https://github.com/kubestash/installer/tree/{{< param "info.version" >}}/charts/kubestash) from [AppsCode Charts Repository](https://github.com/appscode/charts). To install the chart with the release name `kubestash`:
 
+## Get a Free License
+
+Download a FREE license from [AppsCode License Server](https://appscode.com/issue-license?p=stash) before you begin. You can also automate this from your CI/CD pipeline using the [offline license server](https://github.com/appscode/offline-license-server#offline-license-server).
+
 ```bash
 $ helm install kubestash oci://ghcr.io/appscode-charts/kubestash \
         --version {{< param "info.version" >}} \

--- a/docs/setup/install/kubestash/openshift.md
+++ b/docs/setup/install/kubestash/openshift.md
@@ -16,6 +16,10 @@ section_menu_id: setup
 
 There are two ways to deploy KubeStash in [OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift). Use Option A for the standard upstream chart, or Option B if you require the Red Hat OpenShift certified chart (for example, to satisfy a Red Hat OpenShift certification requirement).
 
+## Get a Free License
+
+Download a FREE license from [AppsCode License Server](https://appscode.com/issue-license?p=stash) before you begin. You can also automate this from your CI/CD pipeline using the [offline license server](https://github.com/appscode/offline-license-server#offline-license-server).
+
 ### Option A: Standard chart with OpenShift values
 
 Use the standard [`kubestash` chart](/docs/setup/install/kubestash/helm.md) and enable the OpenShift distribution values. This switches the operator to UBI-based images and applies the SecurityContextConstraints and other OpenShift-specific tweaks:

--- a/docs/setup/install/kubestash/yaml.md
+++ b/docs/setup/install/kubestash/yaml.md
@@ -16,6 +16,10 @@ section_menu_id: setup
 
 If you prefer to not use Helm, you can generate YAMLs from KubeStash chart and deploy using `kubectl`. Here we are going to show the procedure using Helm 3.
 
+## Get a Free License
+
+Download a FREE license from [AppsCode License Server](https://appscode.com/issue-license?p=stash) before you begin. You can also automate this from your CI/CD pipeline using the [offline license server](https://github.com/appscode/offline-license-server#offline-license-server).
+
 ```bash
 $ helm template kubestash oci://ghcr.io/appscode-charts/kubestash \
         --version {{< param "info.version" >}} \


### PR DESCRIPTION
## Summary
- Add a "Get a Free License" section to the Helm, YAML, and OpenShift KubeStash install guides, linking to the AppsCode License Server and the offline license server guide, so readers don't need to go back to the overview page for a license.
- ArgoCD and FluxCD guides are left unchanged since they use the `license-proxyserver` token flow instead of a direct license file.

## Test plan
- [x] Reviewed rendered Markdown for each changed file