### PR TITLE
Prepare for release v2026.8.12-rc.0

### DIFF
--- a/docs/CHANGELOG-v2026.8.12-rc.0.md
+++ b/docs/CHANGELOG-v2026.8.12-rc.0.md
@@ -1,0 +1,120 @@
+---
+title: Changelog | KubeStash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubestash-v2026.8.12-rc.0
+    name: Changelog-v2026.8.12-rc.0
+    parent: welcome
+    weight: 20260812
+product_name: kubestash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.8.12-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.8.12-rc.0/
+---
+
+# KubeStash v2026.8.12-rc.0 (2026-08-12)
+
+
+## [kubestash/apimachinery](https://github.com/kubestash/apimachinery)
+
+### [v0.29.0-rc.0](https://github.com/kubestash/apimachinery/releases/tag/v0.29.0-rc.0)
+
+- [1ee1af06](https://github.com/kubestash/apimachinery/commit/1ee1af06) Clean up cves
+- [0116a4cb](https://github.com/kubestash/apimachinery/commit/0116a4cb) Export CLoud related constants for global usage (#256)
+- [9f8e1079](https://github.com/kubestash/apimachinery/commit/9f8e1079) Resolve Percona pg_tde (17.9-percona) addon version via hard-coded map (#250)
+- [c71e2377](https://github.com/kubestash/apimachinery/commit/c71e2377) Fix SetPathDir (#252)
+- [be80df7c](https://github.com/kubestash/apimachinery/commit/be80df7c) added SnapshotsDirectory = "snapshots" (#254)
+- [5cb309a9](https://github.com/kubestash/apimachinery/commit/5cb309a9) Bump gomodules.xyz/restic to v0.5.1 (#253)
+- [20ceb2f0](https://github.com/kubestash/apimachinery/commit/20ceb2f0) Modernize golangci-lint config (#249)
+
+
+
+## [kubestash/cli](https://github.com/kubestash/cli)
+
+### [v0.28.0-rc.0](https://github.com/kubestash/cli/releases/tag/v0.28.0-rc.0)
+
+- [bb6a6dda](https://github.com/kubestash/cli/commit/bb6a6dda) Prepare for release v0.28.0-rc.0 (#109)
+- [21c9fbbb](https://github.com/kubestash/cli/commit/21c9fbbb) added echo or stdin password update support (#108)
+
+
+
+## [kubestash/installer](https://github.com/kubestash/installer)
+
+### [v2026.8.12-rc.0](https://github.com/kubestash/installer/releases/tag/v2026.8.12-rc.0)
+
+- [6a464d5](https://github.com/kubestash/installer/commit/6a464d5) Prepare for release v2026.8.12-rc.0 (#364)
+- [ed855c2](https://github.com/kubestash/installer/commit/ed855c2) added permission for virual secret (#358)
+- [74d38b6](https://github.com/kubestash/installer/commit/74d38b6) Fix publish oci workflow (#363)
+- [c730293](https://github.com/kubestash/installer/commit/c730293) Allow operator to manage SolrOpsRequests (#362)
+- [69175e1](https://github.com/kubestash/installer/commit/69175e1) Update update-chart-dependencies.sh (#361)
+- [bc3770b](https://github.com/kubestash/installer/commit/bc3770b) Add script to package and chart-verify kubestash-certified for OpenShift (#360)
+- [70c9d9f](https://github.com/kubestash/installer/commit/70c9d9f) Fetch kubestash-certified chart dependencies before regenerating it (#359)
+- [09ad9e9](https://github.com/kubestash/installer/commit/09ad9e9) Add make refresh target and require it before opening a PR (#357)
+
+
+
+## [kubestash/kubedump](https://github.com/kubestash/kubedump)
+
+### [v0.28.0-rc.0](https://github.com/kubestash/kubedump/releases/tag/v0.28.0-rc.0)
+
+- [40be623f](https://github.com/kubestash/kubedump/commit/40be623f) Prepare for release v0.28.0-rc.0 (#100)
+- [f3e92ac1](https://github.com/kubestash/kubedump/commit/f3e92ac1) Modernize golangci-lint config (#99)
+
+
+
+## [kubestash/kubestash](https://github.com/kubestash/kubestash)
+
+### [v0.29.0-rc.0](https://github.com/kubestash/kubestash/releases/tag/v0.29.0-rc.0)
+
+- [c9b5b40b](https://github.com/kubestash/kubestash/commit/c9b5b40b) Merge commit '7ff27267b59cbd2e7c6d83139abb36d29eda9975' into release-0.29
+
+
+
+## [kubestash/manifest](https://github.com/kubestash/manifest)
+
+### [v0.21.0-rc.0](https://github.com/kubestash/manifest/releases/tag/v0.21.0-rc.0)
+
+- [1e60cb14](https://github.com/kubestash/manifest/commit/1e60cb14) Prepare for release v0.21.0-rc.0 (#76)
+- [6b17dd71](https://github.com/kubestash/manifest/commit/6b17dd71) Modernize golangci-lint config (#75)
+
+
+
+## [kubestash/pvc](https://github.com/kubestash/pvc)
+
+### [v0.28.0-rc.0](https://github.com/kubestash/pvc/releases/tag/v0.28.0-rc.0)
+
+- [5dd1a3ab](https://github.com/kubestash/pvc/commit/5dd1a3ab) Prepare for release v0.28.0-rc.0 (#97)
+- [43297935](https://github.com/kubestash/pvc/commit/43297935) Modernize golangci-lint config (#96)
+
+
+
+## [kubestash/vault](https://github.com/kubestash/vault)
+
+### [v0.3.0-rc.0](https://github.com/kubestash/vault/releases/tag/v0.3.0-rc.0)
+
+- [aa9703f](https://github.com/kubestash/vault/commit/aa9703f) Prepare for release v0.3.0-rc.0 (#13)
+
+
+
+## [kubestash/volume-snapshotter](https://github.com/kubestash/volume-snapshotter)
+
+### [v0.28.0-rc.0](https://github.com/kubestash/volume-snapshotter/releases/tag/v0.28.0-rc.0)
+
+- [aaad6553](https://github.com/kubestash/volume-snapshotter/commit/aaad6553) Prepare for release v0.28.0-rc.0 (#82)
+- [25c718f7](https://github.com/kubestash/volume-snapshotter/commit/25c718f7) Modernize golangci-lint config (#81)
+
+
+
+## [kubestash/workload](https://github.com/kubestash/workload)
+
+### [v0.28.0-rc.0](https://github.com/kubestash/workload/releases/tag/v0.28.0-rc.0)
+
+- [cf6ce682](https://github.com/kubestash/workload/commit/cf6ce682) Prepare for release v0.28.0-rc.0 (#108)
+- [54385e42](https://github.com/kubestash/workload/commit/54385e42) Modernize golangci-lint config (#107)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2026.8.12-rc.0
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/54
Signed-off-by: 1gtm <1gtm@appscode.com>